### PR TITLE
Fixed Serializer bug with stdClass

### DIFF
--- a/src/Twig/Extension/AssetExtension.php
+++ b/src/Twig/Extension/AssetExtension.php
@@ -76,8 +76,8 @@ class AssetExtension extends AbstractExtension
      */
     public function renderPhpDataAsJavascript(array $data = [], $phpDataVariableName = 'PhpData')
     {
-        $data = (object) $data;
         $object = $this->serializer->serialize($data, 'json');
+        $object = $object === '[]' ? '{}' : $object;
         $variableName = json_encode($phpDataVariableName);
 
         return <<<JS


### PR DESCRIPTION
When serializing the `stdClass` object, the serializer always return `{}`.

Example:

```php
$foo = new \stdClass();
$foo->bar = 'foobar';
// $data is always {}.
$data = $serializer->serialize($foo, 'json');
```